### PR TITLE
do not fail because of .trashcan directory in GlusterFS mount

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,17 @@
 FROM solr:latest
 
 USER root
+
 ADD nice2_index /opt/solr/server/solr/mycores/nice2_index
 ADD nice2-enterprisesearch-impl-1.0-SNAPSHOT.jar /opt/solr/server/solr/lib
+
 RUN chgrp -R 0 /opt/solr \
   && chmod -R g+rwX /opt/solr \
 
-  # Solr fails to start if timezone on Gluster Cluster differ
-  #
-  # https://bugzilla.redhat.com/show_bug.cgi?id=1430659
-  # https://discuss.elastic.co/t/es-cluster-in-docker-containers-alreadyclosedexception-underlying-file-changed-by-an-external-force/48874
-  && echo "Europe/Zurich" >/etc/timezone
+  # read section 'Timezone' in README.md for why this is needed
+  && echo "Europe/Zurich" >/etc/timezone \
+
+  # read section '.trashcan' in README.md for why this is needed
+  && mkdir /persist \
+  && chgrp 0 /persist/ \
+  && chmod g+rwx /persist

--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
-# solr
+# Solr on Openshift
 [![Build Status](https://travis-ci.org/pgerber/openshift-solr.svg?branch=master)](https://travis-ci.org/pgerber/openshift-solr)
+
+This image is set up to provide search functionality to the [Tocco Business Framework](https://www.tocco.ch). It has been optimized
+to run on the [OpenShift platform](https://www.openshift.com) provided by [VSHN](https://vshn.ch/en/).
+
+## Caveats
+
+### Timezone
+
+Solr fails to start if the timezone on the Gluster Cluster differs. Apparently, the locking mechanism inherited from Lucene wrongfully
+believes that the lock file has been modified. To resolve the issue the timezone is now explicitly set to `Europe/Zurich`
+
+See also:
+* https://bugzilla.redhat.com/show_bug.cgi?id=1430659
+* https://discuss.elastic.co/t/es-cluster-in-docker-containers-alreadyclosedexception-underlying-file-changed-by-an-external-force/48874
+
+
+### .trashcan
+
+In our Openshift environment a persistent volume is mounted from a Gluster cluster. The mount contains a `.trashcan` directory
+and Solr won't have access to it. Unfortunately, Solr can't deal with that. To get it working anyway, the volume is mounted
+at `/persist` and the data directory is a subdirectory of it (`/persist/index_data`). This way `.trashcan` (`/persist/.trashcan`) is no longer
+in Solr's data directory.

--- a/nice2_index/conf/solrconfig.xml
+++ b/nice2_index/conf/solrconfig.xml
@@ -101,7 +101,7 @@
        replication is in use, this should match the replication
        configuration.
     -->
-  <dataDir>${solr.data.dir:}</dataDir>
+  <dataDir>/persist/index_data</dataDir>
 
 
   <!-- The DirectoryFactory to use for indexes.


### PR DESCRIPTION
• create index in subfolder of persistent volume to avoid that
  .trashcan is in data directory
• update README