### PR TITLE
use different prefix for config env. variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ before_install:
   - sudo pip3 install SolrClient
   - docker build -t solr_image .
 script:
-  - run-parts --report tests
+  - run-parts --report --regex 'test_.*' tests

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ to run on the [OpenShift platform](https://www.openshift.com) provided by [VSHN]
 ## Configuration
 
 All configuration parameters available in /opt/solr/bin/solr.in.sh within the image can be overridden using environment variables by
-prefixing `SOLR_`.
+prefixing `SOLR_PARAM_`.
 
 ### Example
 
 Change parameter `SOLR_HEAP=1024m`:
 
 ```
-SOLR_SOLR_HEAP=1024m
+SOLR_PARAM_SOLR_HEAP=1024m
 ```
 
 Take a look at the [sample config](tests/sample_config.conf) used in the tests to see available properties.

--- a/tests/test_generate_conf.sh
+++ b/tests/test_generate_conf.sh
@@ -2,9 +2,9 @@
 set -Eeu
 trap '[ -n "${temp-}" ] && rm -rf "$temp"' EXIT
 
-export SOLR_SOLR_PORT=1234
-export SOLR_SOLR_HEAP=1024m
-export SOLR_ZK_CLIENT_TIMEOUT=300
+export SOLR_PARAM_SOLR_PORT=1234
+export SOLR_PARAM_SOLR_HEAP=1024m
+export SOLR_PARAM_ZK_CLIENT_TIMEOUT=300
 
 temp=$(mktemp -d)
 cp tests/sample_config.conf "$temp/config"

--- a/tocco-solr-config.py
+++ b/tocco-solr-config.py
@@ -4,7 +4,7 @@ import os
 import re
 import sys
 
-PREFIX = 'SOLR_'
+PREFIX = 'SOLR_PARAM_'
 IS_ENTRY = re.compile('^\s*(?P<name>[^=]*)\s*=')
 
 
@@ -22,7 +22,7 @@ def rewrite_config(old, new, config):
         if match:
             name = match.group('name')
             value = config.pop(name, None)
-            if name:
+            if value:
                 write_conf('{}={}\n'.format(name, value))
             else:
                 write_conf(line)


### PR DESCRIPTION
SOLR_* is used by OpenShift already because the container is called
solr.