### PR TITLE
Automatically determine heap memory size

### DIFF
--- a/tocco-solr.sh
+++ b/tocco-solr.sh
@@ -10,5 +10,11 @@ rm -f /persist/index_data/index/write.lock
 # (GC_TUNE, unlike its name suggests, can be used for any Java option)
 echo 'GC_TUNE="-XX:+ExitOnOutOfMemoryError${GC_TUNE+ $GC_TUNE}"' >>/opt/solr/bin/solr.in.sh
 
+# set heap memory based on requested memory
+if [ -z "${SOLR_PARAM_SOLR_HEAP-}" ] && [ -n "${REQUESTED_MEMORY-}" ]; then
+    memory_factor=${MEMORY_FACTOR-0.52}
+    export SOLR_PARAM_SOLR_HEAP=$(awk 'BEGIN { printf "%dm", '$REQUESTED_MEMORY'/1048576 * '$memory_factor' }')
+fi
+
 # entrypoint script shipped with Solr
 exec docker-entrypoint.sh "$@"


### PR DESCRIPTION
When a memory request is set, use it to calculate the how much heap memory should be assigned to Java.